### PR TITLE
Added workaround for ProjectMix control transactions.

### DIFF
--- a/sound/firewire/bebob/bebob.c
+++ b/sound/firewire/bebob/bebob.c
@@ -220,7 +220,7 @@ bebob_probe(struct fw_unit *unit,
 		err = snd_bebob_maudio_special_discover(bebob, true);
 	else if ((entry->vendor_id == VEN_MAUDIO1) &&
 		 (entry->model_id == MODEL_MAUDIO_PROJECTMIX))
-		err = snd_bebob_maudio_special_discover(bebob, false);
+		err = snd_bebob_maudio_special_discover(bebob, true);
 	else
 		err = snd_bebob_stream_discover(bebob);
 	if (err < 0)


### PR DESCRIPTION
Hi again.

I've gone ahead and modified the code in order to make sure that ProjectMix control transactions run smoothly. The same firewire bus reset that is applied to the fw1814 must also be applied to the ProjectMix.

I've tested it with my ProjectMix and it works absolutely fine, with no issues whatsoever. I now have smooth control without having to manually reset the bus :).

Regards,
Darren